### PR TITLE
feature: add CSS properties as documentation to completion item

### DIFF
--- a/lua/bootstrap-cmp/init.lua
+++ b/lua/bootstrap-cmp/init.lua
@@ -32,14 +32,18 @@ function Source:complete(_, callback)
 			return
 		end
 
-		self.selectors = utils.extract_selectors(self.file)
+		self.rules = utils.extract_rules(self.file)
 
-		self.filtered_table = utils.remove_duplicates(self.selectors)
+		self.filtered_table = utils.remove_duplicates(self.rules)
 
-		for _, class in ipairs(self.filtered_table) do
+		for _, rule in ipairs(self.filtered_table) do
 			table.insert(self.items, {
-				label = class,
+				label = rule['class_name'],
 				kind = cmp.lsp.CompletionItemKind.Enum,
+        documentation = {
+          kind = 'markdown',
+          value = '```css\n' .. rule['css_properties'] .. '\n```'
+        }
 			})
 		end
 


### PR DESCRIPTION
The documentation is returned as markdown markup.

1. Without CSS code block:
~~~
```
display: none !important
```
~~~

![Screen Shot 2023-08-05 at 12 19 39](https://github.com/Jezda1337/cmp_bootstrap/assets/35915460/42a8ee1d-f1cc-4cdb-9fbd-664f4d40cfaf)

2. With CSS code block:
~~~
```css
display: none !important
```
~~~

![Screen Shot 2023-08-05 at 12 20 04](https://github.com/Jezda1337/cmp_bootstrap/assets/35915460/6ae7b6aa-e0ff-45b9-8f70-9aaa82d8b53d)

The current implementation goes with the second one. If you want another style, please tell me.
